### PR TITLE
Disable relaunch in the elasticjob operator

### DIFF
--- a/dlrover/go/operator/Dockerfile
+++ b/dlrover/go/operator/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 # Copy the go source
 COPY main.go main.go
 COPY api/ api/
-COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/dlrover/go/operator/pkg/controllers/psstrategy/strategy.go
+++ b/dlrover/go/operator/pkg/controllers/psstrategy/strategy.go
@@ -14,7 +14,6 @@
 package psstrategy
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	elasticv1alpha1 "github.com/intelligent-machine-learning/easydl/dlrover/go/operator/api/v1alpha1"

--- a/dlrover/go/operator/pkg/controllers/psstrategy/strategy.go
+++ b/dlrover/go/operator/pkg/controllers/psstrategy/strategy.go
@@ -151,6 +151,9 @@ func (m *PSTaskManager) getTaskStatus(
 }
 
 func (m *PSTaskManager) getTotalTaskCount(taskStatus *commonv1.ReplicaStatus) int {
+	if taskStatus == nil {
+		return 0
+	}
 	return int(taskStatus.Active + taskStatus.Pending + taskStatus.Succeeded + taskStatus.Failed)
 }
 
@@ -263,14 +266,7 @@ func (m *PSTaskManager) HandleFaultPods(
 	}
 	for _, pod := range replicaPods {
 		if pod.DeletionTimestamp != nil {
-			logger.Infof("Pod %s is deleted and will be relaunched", pod.Name)
-			totalReplicaCount := m.getTotalTaskCount(job.Status.ReplicaStatuses[m.taskType])
-			pod.Name = m.newTaskName(job.Name, totalReplicaCount)
-			err := client.Create(context.Background(), pod.DeepCopy())
-			if err != nil {
-				return err
-			}
-
+			logger.Infof("Pod %s is deleted", pod.Name)
 		} else if pod.Status.Phase == corev1.PodFailed {
 			if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].State.Terminated != nil {
 				terminated := pod.Status.ContainerStatuses[0].State.Terminated


### PR DESCRIPTION
Fix #113 

The master controls the logic to relaunch failed Pods. We do not need the logic in the controller.